### PR TITLE
Change to compileOnly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0'
+    compileOnly 'com.android.support:support-annotations:28.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'


### PR DESCRIPTION
using `implementation` will include the transitive dependency in the app project.  We do not need this dependency at the app level - we only need it for the library.  `compileOnly` will make sure that only the library will compile this dependency and the app will not try to import the dependency.

https://github.com/simplymadeapps/frontdesk-android/pull/36/files#diff-a2b0330378c75cf4dc4b83a0e026b6f4