### PR TITLE
Add remove method to remove a key

### DIFF
--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -28,6 +28,11 @@ public class PreferenceHelper {
         return preferences.contains(key);
     }
 
+    public static void remove(String key) {
+        editor.remove(key);
+        editor.commit();
+    }
+
     private static <T> boolean isTypePrimitive(Class<T> type) {
         return type.equals(Integer.class) ||
                 type.equals(Boolean.class) ||

--- a/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
+++ b/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
@@ -105,6 +105,20 @@ public class PreferenceHelperTests {
         }
     }
 
+    public static class RemoveTests {
+
+        @Test
+        public void test_remove() {
+            SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+            PreferenceHelper.editor = editor;
+
+            PreferenceHelper.remove("key");
+
+            verify(editor, times(1)).remove("key");
+            verify(editor, times(1)).commit();
+        }
+    }
+
     public static class IsTypePrimitiveTests {
 
         @Test


### PR DESCRIPTION
There is a scenario in the app where we would like to remove a stored key (which would be smarter than just setting it back to a default value).