### PR TITLE
LIB-30: PreferenceHelper Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ implementation 'com.github.simplymadeapps:PreferenceHelper:2.0.0'
 ```
 
 ## Usage
-#### Initialize
+### Initialize
 Init the library in the `Application.onCreate()` method.  You can also put this at that top of your start activity's `onCreate()`.  All that matters is `init()` is called before any other calls to the PreferenceHelper.
 ```java
 public class MyApplication extends Application {
@@ -27,7 +27,7 @@ public class MyApplication extends Application {
 }
 ```
 
-#### Get/Set
+### Get/Set
 Now that the library has been initialized, you can easily use `put()` and `get()`.
 
 Storing an object:
@@ -40,7 +40,7 @@ Getting an object:
 String username = PreferenceHelper.get("current_user_name", "No Name");
 ```
 
-#### Handling nulls
+### Handling nulls
 The library is using the object type of the input or fallback to determine what SharedPreference method to use (ex, putString, putLong, putInt, etc).
 This can cause confusion when you pass in a null object as one of these parameters.  If you need to store a null object or retrieve an object with a null fallback you should pass in that object type.
 
@@ -55,29 +55,30 @@ Set<String> usernames = PreferenceHelper.get("all_names", null, Set.class);
 ```
 Note that primitive types (int, boolean, float, long) cannot be null.
 
-#### Contains
+### Contains
 You can also check if a value has been stored with: 
 ```
 boolean key_exists = PreferenceHelper.contains("some_key");
 ```
 
-#### Removing
-You can remove an object at a key with
+### Removing
+You can remove an object at a key with:
 ```
 PreferenceHelper.remove("some_key");
 ```
 
-#### Custom Objects
+### Custom Objects
 The PreferenceHelper can also store non-primitive objects.  Your object will be serialized and stored as a JSON string.
 ```
 PreferenceHelper.put("current_user", user);
 User user = PreferenceHelper.get("current_user", null, User.class);
 ```
-#### Custom Objects with Type Parameters
-**NOTE: As of now, the library is not able to easily retrieve objects that use type parameter aside from List<>**
+### Custom Objects with Type Parameters
+**NOTE: As of now, the library is not able to easily retrieve objects that use type parameter aside from List**
+
 Due to type erasure at compile time, the library will not know what type parameter type to convert the objects to.
 For example, retrieving something like `Response<APIResponse>` likely will not work properly as it will return you a generic Response object with no type param set.
-**However, a workaround for retrieving a List<> of objects has been added...**
+**However, a workaround for retrieving a List of objects has been added...**
 ```
 List<User> fallbackList = new ArrayList<>();
 List<User> userList = PreferenceHelper.getList("list_key", fallbackList, User[].class);
@@ -85,6 +86,7 @@ List<User> userList = PreferenceHelper.getList("list_key", fallbackList, User[].
 This will look up the object array stored at that key and turn it into a List of that object type.
 If nothing is stored, the fallback will be returned.  If a null value is stored, a null list will be returned.
 If the stored object at the specified key is not a valid array or list of the desired object, an exception will be thrown.
+
 **NOTE: This only applies to retrieving objects as a substitute for `get()`. You should still use `put()` to store a List.**
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PreferenceHelper
-A more painless way to set/get with SharedPreferences.
-# Getting Started
+A powerful, painless way to utilize SharedPreferences.
+## Getting Started
 Add it in your root build.gradle at the end of repositories:
 ```groovy
 allprojects {
@@ -11,10 +11,11 @@ allprojects {
 ```
 Add the following to the dependencies section of app/build.gradle (check Releases for the latest version):
 ```
-implementation 'com.github.simplymadeapps:PreferenceHelper:1.1.1'
+implementation 'com.github.simplymadeapps:PreferenceHelper:2.0.0'
 ```
 
-# Usage
+## Usage
+#### Initialize
 Init the library in the `Application.onCreate()` method.  You can also put this at that top of your start activity's `onCreate()`.  All that matters is `init()` is called before any other calls to the PreferenceHelper.
 ```java
 public class MyApplication extends Application {
@@ -25,6 +26,8 @@ public class MyApplication extends Application {
     }
 }
 ```
+
+#### Get/Set
 Now that the library has been initialized, you can easily use `put()` and `get()`.
 
 Storing an object:
@@ -37,6 +40,7 @@ Getting an object:
 String username = PreferenceHelper.get("current_user_name", "No Name");
 ```
 
+#### Handling nulls
 The library is using the object type of the input or fallback to determine what SharedPreference method to use (ex, putString, putLong, putInt, etc).
 This can cause confusion when you pass in a null object as one of these parameters.  If you need to store a null object or retrieve an object with a null fallback you should pass in that object type.
 
@@ -51,24 +55,44 @@ Set<String> usernames = PreferenceHelper.get("all_names", null, Set.class);
 ```
 Note that primitive types (int, boolean, float, long) cannot be null.
 
-
+#### Contains
 You can also check if a value has been stored with: 
 ```
 boolean key_exists = PreferenceHelper.contains("some_key");
 ```
 
+#### Removing
+You can remove an object at a key with
+```
+PreferenceHelper.remove("some_key");
+```
+
+#### Custom Objects
 The PreferenceHelper can also store non-primitive objects.  Your object will be serialized and stored as a JSON string.
 ```
 PreferenceHelper.put("current_user", user);
 User user = PreferenceHelper.get("current_user", null, User.class);
 ```
+#### Custom Objects with Type Parameters
+**NOTE: As of now, the library is not able to easily retrieve objects that use type parameter aside from List<>**
+Due to type erasure at compile time, the library will not know what type parameter type to convert the objects to.
+For example, retrieving something like `Response<APIResponse>` likely will not work properly as it will return you a generic Response object with no type param set.
+**However, a workaround for retrieving a List<> of objects has been added...**
+```
+List<User> fallbackList = new ArrayList<>();
+List<User> userList = PreferenceHelper.getList("list_key", fallbackList, User[].class);
+```
+This will look up the object array stored at that key and turn it into a List of that object type.
+If nothing is stored, the fallback will be returned.  If a null value is stored, a null list will be returned.
+If the stored object at the specified key is not a valid array or list of the desired object, an exception will be thrown.
+**NOTE: This only applies to retrieving objects as a substitute for `get()`. You should still use `put()` to store a List.**
 
-# Contributing
+## Contributing
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-# License
+## License
 The library is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This will look up the object array stored at that key and turn it into a List of
 If nothing is stored, the fallback will be returned.  If a null value is stored, a null list will be returned.
 If the stored object at the specified key is not a valid array or list of the desired object, an exception will be thrown.
 
-**NOTE: This only applies to retrieving objects as a substitute for `get()`. You should still use `put()` to store a List.**
+Similarly to `get()` and `getList()` you should use `putList()` instead of `put()` when you are attempting to store a list of objects.
 
 ## Contributing
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -74,20 +74,22 @@ PreferenceHelper.put("current_user", user);
 User user = PreferenceHelper.get("current_user", null, User.class);
 ```
 ### Custom Objects with Type Parameters
-**NOTE: As of now, the library is not able to easily retrieve objects that use type parameter aside from List**
+Due to type erasure at compile time, the library will not know what type parameter type to convert the objects to when deserializing.
+For example, retrieving something like `HashMap<String, String>` will not work properly as it will return you a generic HashMap object with unknown type params.
 
-Due to type erasure at compile time, the library will not know what type parameter type to convert the objects to.
-For example, retrieving something like `Response<APIResponse>` likely will not work properly as it will return you a generic Response object with no type param set.
-**However, a workaround for retrieving a List of objects has been added...**
+The only object with type params that the library will handle properly is List objects.  Use `getList()` and `putList()` instead of the regular `get()` and `put()`.
 ```
+// Store the list
+List<User> userList = new ArrayList<>();
+PreferenceHelper.putList("list_key", userList);
+
+// Retrieve the list
 List<User> fallbackList = new ArrayList<>();
 List<User> userList = PreferenceHelper.getList("list_key", fallbackList, User[].class);
 ```
 This will look up the object array stored at that key and turn it into a List of that object type.
 If nothing is stored, the fallback will be returned.  If a null value is stored, a null list will be returned.
 If the stored object at the specified key is not a valid array or list of the desired object, an exception will be thrown.
-
-Similarly to `get()` and `getList()` you should use `putList()` instead of `put()` when you are attempting to store a list of objects.
 
 ## Contributing
 1. Fork it

--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -110,10 +110,15 @@ public class PreferenceHelper {
         }
         else {
             // Store a custom non-primitive object as JSON string
+            System.out.println(new Gson().toJson(value, instanceType));
             editor.putString(key, new Gson().toJson(value, instanceType));
         }
 
         editor.commit();
+    }
+
+    public static <T> void putList(@NonNull String key, List<T> value) {
+        put(key, value, List.class);
     }
 
     public static <T> T get(@NonNull String key, T fallback) {

--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -8,8 +8,14 @@ import android.support.annotation.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class PreferenceHelper {
@@ -158,6 +164,26 @@ public class PreferenceHelper {
         }
         catch(JsonSyntaxException e) {
             throw new IllegalArgumentException("The object stored at the specified key is not an instance of " + instanceType.getName(), e);
+        }
+    }
+
+    public static <T> List<T> getList(String key, List<T> fallback, Class<T[]> type) {
+        if(!contains(key)) {
+            // No record exists for this key - return their fallback object
+            return fallback;
+        }
+
+        try {
+            String objectAsJson = preferences.getString(key, null);
+            T[] fromJson = (T[]) new Gson().fromJson(objectAsJson, type);
+            if(fromJson == null) {
+                return null;
+            }
+            List<T> result = new ArrayList<>(Arrays.asList(fromJson));
+            return result;
+        }
+        catch(RuntimeException e) {
+            throw new IllegalArgumentException("The object stored at the specified key is not a " + type.getSimpleName(), e);
         }
     }
 }

--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -158,6 +158,10 @@ public class PreferenceHelper {
             return fallback;
         }
 
+        if(List.class.isAssignableFrom(instanceType)) {
+            throw new IllegalArgumentException("Please use getList() instead of get() when retrieving a list of stored objects.");
+        }
+
         String objectAsJson = preferences.getString(key, null);
         try {
             return new Gson().fromJson(objectAsJson, instanceType);

--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -110,7 +110,6 @@ public class PreferenceHelper {
         }
         else {
             // Store a custom non-primitive object as JSON string
-            System.out.println(new Gson().toJson(value, instanceType));
             editor.putString(key, new Gson().toJson(value, instanceType));
         }
 

--- a/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
+++ b/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
@@ -501,6 +501,18 @@ public class PreferenceHelperTests {
         }
 
         @Test
+        public void test_getCustomObject_exists_withListException() throws Exception {
+            doReturn(true).when(PreferenceHelper.preferences).contains(key);
+            List<UUID> listFallback = new ArrayList<>();
+            expectedException.expect(IllegalArgumentException.class);
+            expectedException.expectMessage("Please use getList() instead of get() when retrieving a list of stored objects.");
+
+            UUID result = Whitebox.invokeMethod(PreferenceHelper.class, "getCustomObject", key, listFallback, listFallback.getClass());
+
+            // Assertion handled via expectedException
+        }
+
+        @Test
         public void test_getCustomObject_exists_noException() throws Exception {
             doReturn(true).when(PreferenceHelper.preferences).contains(key);
             doReturn("json").when(PreferenceHelper.preferences).getString(key, null);
@@ -513,7 +525,7 @@ public class PreferenceHelperTests {
         }
 
         @Test
-        public void test_getCustomObject_exists_withException() throws Exception {
+        public void test_getCustomObject_exists_withJsonException() throws Exception {
             doReturn(true).when(PreferenceHelper.preferences).contains(key);
             doReturn("json").when(PreferenceHelper.preferences).getString(key, null);
             JsonSyntaxException jsonSyntaxException = mock(JsonSyntaxException.class);

--- a/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
+++ b/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -34,11 +35,13 @@ import static org.mockito.Matchers.anySet;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
@@ -349,6 +352,22 @@ public class PreferenceHelperTests {
 
             verify(PreferenceHelper.editor, times(1)).putString("key", "json");
             verify(PreferenceHelper.editor, times(1)).commit();
+        }
+    }
+
+    @RunWith(PowerMockRunner.class)
+    @PrepareForTest({PreferenceHelper.class})
+    public static class PutListTests {
+
+        @Test
+        public void test_putList() throws Exception {
+            spy(PreferenceHelper.class);
+            List<UUID> list = new ArrayList<>();
+            doNothing().when(PreferenceHelper.class, "put", "key", list, List.class);
+
+            PreferenceHelper.putList("key", list);
+
+            verifyPrivate(PreferenceHelper.class, times(1)).invoke("put", "key", list, List.class);
         }
     }
 


### PR DESCRIPTION
In TimeClock, we don't just store an entire `Company` object.  We store company data in their own individual lists.

This is problematic for the PreferenceHelper's new object storage.  Because of type erasure when working with java Generic types, if I tell the PreferenceHelper that I want back a `List<Beacon>` all it knows is that I want back a List and I have would have to cast every object in that returned list to be a Beacon before using it (because it is just a list of unknown objects).

This would apply to any object with type params.  If you want to store a Map<String, Integer> or something similar, the `get()` method will return you a Map of unknown objects.

This PR adds a workaround for List objects.  You can now call `getList(String key, List<T> fallback, Class<T[]> type)` instead of the usual `get()`.

View the changes in the readme more a more detailed example of the `getList()` method.