### PR TITLE
FAF-344: PreferenceHelper.clear()

### DIFF
--- a/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
+++ b/app/src/main/java/com/simplymadeapps/preferencehelper/PreferenceHelper.java
@@ -42,6 +42,11 @@ public class PreferenceHelper {
         editor.commit();
     }
 
+    public static void clear() {
+        editor.clear();
+        editor.commit();
+    }
+
     private static <T> boolean isTypePrimitive(Class<T> type) {
         return type.equals(Integer.class) ||
                 type.equals(Boolean.class) ||

--- a/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
+++ b/app/src/test/java/com/simplymadeapps/preferencehelper/PreferenceHelperTests.java
@@ -131,6 +131,20 @@ public class PreferenceHelperTests {
         }
     }
 
+    public static class ClearTests {
+
+        @Test
+        public void test_clear() {
+            SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+            PreferenceHelper.editor = editor;
+
+            PreferenceHelper.clear();
+
+            verify(editor, times(1)).clear();
+            verify(editor, times(1)).commit();
+        }
+    }
+
     public static class IsTypePrimitiveTests {
 
         @Test


### PR DESCRIPTION
Adds a new method to the PreferenceHelper to clear all items in storage.