### PR TITLE
LIBDROID-43: Gradle & CVEs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,12 +13,14 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Vulnerability Check
+        run: ./gradlew dependencyCheckAnalyze
       - name: Lint
         run: ./gradlew lintRelease
       - name: Run Tests

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,18 +1,23 @@
 apply plugin: 'com.android.library'
+apply plugin: 'org.owasp.dependencycheck'
 apply from: 'jacoco_offline.gradle'
 
 android {
     namespace 'com.simplymadeapps.preferencehelper'
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 31
+        targetSdkVersion 33
     }
     lintOptions {
         warningsAsErrors true
         disable 'GradleDependency'
         informational 'OldTargetApi'
     }
+}
+
+dependencyCheck {
+    failBuildOnCVSS = 7
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ dependencyCheck {
 }
 
 dependencies {
-    api 'com.google.code.gson:gson:2.8.6'
+    api 'com.google.code.gson:gson:2.10.1'
     compileOnly 'com.android.support:support-annotations:28.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.github.stephenruda.powermock:powermock-api-mockito:2dbb804cc4'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply from: 'jacoco_offline.gradle'
 
 android {
+    namespace 'com.simplymadeapps.preferencehelper'
     compileSdkVersion 31
     defaultConfig {
         minSdkVersion 15
@@ -18,6 +19,17 @@ dependencies {
     api 'com.google.code.gson:gson:2.8.6'
     compileOnly 'com.android.support:support-annotations:28.0.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
+    testImplementation 'com.github.stephenruda.powermock:powermock-api-mockito:2dbb804cc4'
+    testImplementation 'com.github.stephenruda.powermock:powermock-module-junit4:2dbb804cc4'
+    testImplementation 'org.javassist:javassist:3.29.2-GA'
+}
+
+tasks.withType(Test).configureEach { task ->
+    task.jvmArgs += [
+            // These are the classes we need to open up in order for PowerMock to work
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED"
+    ]
 }

--- a/app/jacoco_offline.gradle
+++ b/app/jacoco_offline.gradle
@@ -8,7 +8,7 @@ configurations {
 }
 
 jacoco {
-    toolVersion = "0.8.6"
+    toolVersion = "0.8.8"
 }
 
 def offline_instrumented_outputDir = "$buildDir.path/intermediates/classes-instrumented/debug"
@@ -42,8 +42,8 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "test") {
 
 jacocoTestReport {
     reports {
-        xml.enabled  true
-        html.enabled  true
+        xml.required = true
+        html.required = true
         html.destination file("build/test-results/jacocoHtml")
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.simplymadeapps.preferencehelper" />
+<manifest />

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'org.owasp:dependency-check-gradle:8.3.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 
@@ -14,5 +14,6 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Update to Gradle 8.1
- Update to Java 17 which Gradle 8.1 requires
- Introduce the vulnerability check.  [Here is a purposefully failed build to prove that it is working.](https://github.com/simplymadeapps/PreferenceHelper/actions/runs/5929795583/job/16078210906?pr=13)
- Updated the `com.google.code.gson` which was the only vulnerable dependency